### PR TITLE
Add rebase drawbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,14 @@ It's useful in several situations, e.g.:
 - Joining separate changes that make more sense when applied together
 - Rewriting _work in progress_ commits
 
+### When to avoid rebase or squash?
+
+Both rebase and squash commands substitutes existing commits for new ones. So it's not recommended to use with branches/commits that are being referenced by others or exists on the remote repository.
+
+Because when we are rebasing or squashing commits that anyone depends on and were not yet pushed to the remote repository, it will have no side effects. But, if the commits exist already on a remote repository and we try push our changes, git will identify that our commits diverge from the commits that exists on the repository and will fail requesting us to get those existing commits from the repository, but that would end of duplicating or maintaining the commits we tried change.
+
+There are ways to force the push to the repository, but that would be too dangerous to be done on a branch used by other people, generating conflicts to everyone else.
+
 ## Useful git commands
 
 ### rebase -i

--- a/README.md
+++ b/README.md
@@ -267,11 +267,8 @@ It's useful in several situations, e.g.:
 
 ### When to avoid rebase or squash?
 
-Both rebase and squash commands substitutes existing commits for new ones. So it's not recommended to use with branches/commits that are being referenced by others or exists on the remote repository.
-
-Because when we are rebasing or squashing commits that anyone depends on and were not yet pushed to the remote repository, it will have no side effects. But, if the commits exist already on a remote repository and we try push our changes, git will identify that our commits diverge from the commits that exists on the repository and will fail requesting us to get those existing commits from the repository, but that would end of duplicating or maintaining the commits we tried change.
-
-There are ways to force the push to the repository, but that would be too dangerous to be done on a branch used by other people, generating conflicts to everyone else.
+Avoid rebase and squash in public commits or in shared branches where multiple people work on.
+Rebase and squash rewrite history and overwrite existing commits, doing it on commits that are on shared branches (i.e., commits pushed to remote repository or that comes from others branches) can cause confusion and people may lost their changes (both locally and remotely) because of divergent trees and conflicts.
 
 ## Useful git commands
 

--- a/README_pt-BR.md
+++ b/README_pt-BR.md
@@ -249,6 +249,14 @@ Squash é o processo de pegar uma série de commits e juntá-los em um commit s�
 - Mudanças que estão em _commits_ separados que fariam mais sentido parte de um só
 - _Commits WIP_
 
+### Quando evitar rebase ou squash?
+
+Tanto rebase e squash substituem commits que existem por novos. Portanto, não é recomendável usar esses commandos em branches/commits que estão aplicados em outras branches ou que existam no repositório remoto.
+
+Isso porque, quando fazemos o rebase ou squash de commits que nenhuma outra branch dependa e não existe no repositório remoto, não haverá nenhum efeito colateral. Porém, se os commits já existem em outras branches ou no repositório remoto, quando tentarmos enviar nossas modificações, git identificará que existe uma divergência entre os commits locais e remotos, e pedirá que os commits que existem no repositório sejam recuperados antes de enviar os novos, mais isso vai acabar duplicando os commits ou mantendo os commits que tentamos consolidar.
+
+Existem algumas maneiras de forçar o push para o repositório, mais isso seria muito arriscado em uma branch usada por outras pessoas, gerando conflitos para todos os outros.
+
 ## Comandos úteis
 
 ### rebase -i

--- a/README_pt-BR.md
+++ b/README_pt-BR.md
@@ -251,11 +251,8 @@ Squash é o processo de pegar uma série de commits e juntá-los em um commit s�
 
 ### Quando evitar rebase ou squash?
 
-Tanto rebase e squash substituem commits que existem por novos. Portanto, não é recomendável usar esses commandos em branches/commits que estão aplicados em outras branches ou que existam no repositório remoto.
-
-Isso porque, quando fazemos o rebase ou squash de commits que nenhuma outra branch dependa e não existe no repositório remoto, não haverá nenhum efeito colateral. Porém, se os commits já existem em outras branches ou no repositório remoto, quando tentarmos enviar nossas modificações, git identificará que existe uma divergência entre os commits locais e remotos, e pedirá que os commits que existem no repositório sejam recuperados antes de enviar os novos, mais isso vai acabar duplicando os commits ou mantendo os commits que tentamos consolidar.
-
-Existem algumas maneiras de forçar o push para o repositório, mais isso seria muito arriscado em uma branch usada por outras pessoas, gerando conflitos para todos os outros.
+Evite _rebase_ e _squash_ em _commits_ públicos ou em _branches_ compartilhadas que outras pessoas possam ter trabalhado.
+_Rebase_ e _squash_ reescrevem a história sobrescrevendo commits existentes, fazendo isso em commits que existam em _branches_ compartilhadas (i.e., _commits_ enviados para repositórios remotos ou originados de outras branches) podem causar confusão e as pessoas podem perder suas modificações (tanto locais quanto remotas) por causa de divergências e conflitos.
 
 ## Comandos úteis
 


### PR DESCRIPTION
Mention the drawbacks of rebases and squashes on commits that exists on remote repository or that come from other branches that might be referenced by others.

Relates to #8 