### PR TITLE
Add a contributing guideline

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,72 @@
+# Contributing
+
+First of all, thanks for the taking time to contribute and help people!
+
+This document contains a set of guidelines for contributing to the repository. These guidelines are intended to provide a clear and concise to help you to know where help is needed and how you can contribute to improve the guide.
+
+## Where can I help?
+
+There are several ways to contribute. A contribution could happen both in the form of changes to the repository itself or through pull request reviews. Any kind of help would be appreciated.
+
+In special, I'd like to highlight and bring attention to help in the form of:
+
+- Fix of inconsistencies across languages
+- Grammar and spelling corrections
+- Improvement of source referencing (images, references, etc.)
+- Incorrect, inconsistent or incomplete information fixes
+- Pull request reviews
+- Translation to other languages
+
+## Tenets
+
+- **Consistency across languages over 100% correct grammar/spelling**: It's better to have some grammar and spelling errors than having outdated or specialized content for a single language. Use Google Translate or similar tools when needed.
+- **Best practices in this guide should aim to help, not to set rule-following blindly standards**: It's intended to provide resourceful guidelines to help people communicate in a better, concise and clear way. It's a mean to an end, not the end itself.
+- **One size does not fit all**: A project, team or company standards and agreements may override common practices. People may not agree 100% with all practices and it's ok. These things should not led to add or remove a guideline. Helping people should.
+- **Native speakers are owners, but two heads are better than one**: Pull request authors do the best they can, but this doesn't replaces a good review by another native speaker.
+
+Feel free to propose improvements if you have.
+
+## Guidelines
+
+Try to follow these guidelines when contributing. They're not rules and I'll not strictly enforce them, although I may ask you to adapt your contribution according to it.
+
+Feel free to propose changes to the guidelines and use your best judgment.
+
+### General guidelines
+
+- You may fork the project to make changes to the repository. See [this Github guide](https://guides.github.com/activities/forking/) explaining how to do it.
+- Use English for commit messages, issues and pull requests (both description and discussions).
+- Use the [best practices](https://github.com/RomuloOliveira/commit-messages-guide#good-practices) described in the guide.
+- Add `[PROPOSAL]` prefix to PR title when doing additions other than translations or corrections (e.g., [#31](https://github.com/RomuloOliveira/commit-messages-guide/pull/31))
+- Github editor usually suggests a commit message like "Update file", add a description of your change in the commit body or change the title.
+    - A good example: [7747659](https://github.com/RomuloOliveira/commit-messages-guide/commit/7747659824b83f6d07589daa66a67ee29fa60ddb)
+
+It worth noting again that the best practices described in this guide are _guidelines_ and not rules. I won't refuse your contribution nor nitpick your commit messages if you're not following them strictly. It aims to help.
+
+### New translation checklist
+
+- Make sure you're working in the most updated branch. Rebase your code and fix conflicts when needed.
+- Make sure you've updated the [Available languages section](https://github.com/RomuloOliveira/commit-messages-guide#available-languages) section in (and only in) README.md.
+- Make sure you haven't included `Available languages` section in your translation (See [#31](https://github.com/RomuloOliveira/commit-messages-guide/pull/31)).
+
+### Pull Request review process
+
+Preferably, there should be at least 1 review from a native speaker. All pull requests will stay open for a few days waiting for a review help. Translations that didn't had a thorough review by a native speakers should be merged in a couple days, though.
+
+All discussions should be resolved before a merge. Only [code owners](https://github.com/RomuloOliveira/commit-messages-guide/blob/master/CODEOWNERS) can do a merge. Native speakers have the authority to request changes in any pull request.
+
+Everything that applies to a native speaker also applies to a fluent writer.
+
+## Author notes
+
+_by @RomuloOliveira_
+
+I'm a Brazilian Portuguese native speaker still working on my English. I'll try to review all translations using Google Translate but a native speaker review is way more valuable.
+
+I'll open pull requests for significant changes and proposals, but I may commit directly to the master branch for minor fixes or changes that do not affect translations' content.
+
+Opinions and contents are my own and don't necessarily represent those of my current or former employers.
+
+## Thanks
+
+Helping people is priceless and I thank every and each of you that contributed to this guide.


### PR DESCRIPTION
Add a contributing guideline containing where help is needed, repo tenets, contributing guidelines and author notes.

I just wrote down some unwritten rules I've been using since the repo creation. I expect that this enables more contributions (through tenets, guidelines and clarification of review process).

I'd like some thoughts on it, I intend to merge it in a few days. All reviewers are welcome.