### PR TITLE
Correct 'Good' and 'Bad' examples in README_ja-JP.md

### DIFF
--- a/README_ja-JP.md
+++ b/README_ja-JP.md
@@ -78,7 +78,7 @@ Add `use` method
 ```
 
 ```
-# 悪い例
+# 良い例
 Increase left padding between textbox and layout frame
 ```
 


### PR DESCRIPTION
It probably have been a 'good example,' but it turned out to be a 'bad example' in the Japanese README, so I corrected it.