### PR TITLE
[Proposal] signing commits, writing good cover letters and other kernel dev inspirations

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,6 @@ You don't have to refer to the commit by itself. We **know** that this is a patc
 
 ```
 # Bad
-
 This commit does x and y...
 
 This PR does x and y...
@@ -180,6 +179,19 @@ This Patch x and y...
 # Good
 
 X and y are done...
+```
+
+### Avoid personal language (e.g. pronouns)
+
+A thing that can be learned from academic writing and brought to commit messages is to avoid using personal
+language.
+
+```
+# Bad
+I fixed the problem.
+
+# Good
+The problem has been fixed by doing x and y...
 ```
 
 ### Limit the number of characters

--- a/README.md
+++ b/README.md
@@ -164,6 +164,10 @@ Change stuff
 Adjust css
 ```
 
+### Avoid language such as "this PR", "this commit", "this patch"
+
+You don't have to refer to the commit by itself. We **know** that this is a patch, commit or PR.
+
 ### Limit the number of characters
 
 [It's recommended](https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines) to use a maximum of 50 characters for the subject and 72 for the body.

--- a/README.md
+++ b/README.md
@@ -247,6 +247,20 @@ Resolves: #123
 See also: #456, #789
 ```
 
+## Notes on PR messages and cover letters
+
+Most developers open Pull Requests (PR) on a Git repo through a platform (Github, Gitlab),
+while kernel developers  and people who send patches through email ([yes, that's a
+thing](https://git-scm.com/docs/git-send-email/2.45.0) refer to it as "cover letter".
+
+A good cover letter, or PR message, will summarize, give background and context to a series of
+commits that are related. Good writing on this part will help to "sell" your commit series to
+the maintainers of a project, as they'll be able to understand why you are presenting such changes
+together.
+
+If you're writing a smaller (single or a few commits) change, treat the first commit as a cover letter.
+Github, for example, uses this first commit as the default PR message.
+
 ## Rebase vs. Merge
 
 This section is a **TL;DR** of Atlassian's excellent tutorial, ["Merging vs. Rebasing"](https://www.atlassian.com/git/tutorials/merging-vs-rebasing).

--- a/README.md
+++ b/README.md
@@ -261,6 +261,20 @@ together.
 If you're writing a smaller (single or a few commits) change, treat the first commit as a cover letter.
 Github, for example, uses this first commit as the default PR message.
 
+Here's an [example](https://lore.kernel.org/lkml/20230414225551.858160935@linutronix.de/) of a good cover
+letter sent on the Linux kernel mailing list. It contains:
+
+- A description of the overall changes and why they were made;
+
+- Background, or any important information that is needed to understand these changes;
+
+- A breakdown of the solution and the approach taken to reach such solution;
+
+- Caveats, or things that could go wrong and must be considered before applying such changes;
+
+- Possible enhancements, a section describing opportunities for future changes that are out of the scope
+  for the current commit set;
+
 ## Rebase vs. Merge
 
 This section is a **TL;DR** of Atlassian's excellent tutorial, ["Merging vs. Rebasing"](https://www.atlassian.com/git/tutorials/merging-vs-rebasing).

--- a/README.md
+++ b/README.md
@@ -168,6 +168,20 @@ Adjust css
 
 You don't have to refer to the commit by itself. We **know** that this is a patch, commit or PR.
 
+```
+# Bad
+
+This commit does x and y...
+
+This PR does x and y...
+
+This Patch x and y...
+
+# Good
+
+X and y are done...
+```
+
 ### Limit the number of characters
 
 [It's recommended](https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project#_commit_guidelines) to use a maximum of 50 characters for the subject and 72 for the body.

--- a/README.md
+++ b/README.md
@@ -287,6 +287,48 @@ letter sent on the Linux kernel mailing list. It contains:
 - Possible enhancements, a section describing opportunities for future changes that are out of the scope
   for the current commit set;
 
+## Signing off your commits and following guidelines
+
+Open source projects often require you to sign your code and follow some guidelines. One such example is
+the Developer Certificate of Origin (DCO)[https://developercertificate.org/], which you have to abide to
+when contributing to projects by The Linux Foundation, the Cloud Native Computing Foundation and many
+others.
+
+This means that you have to use your **real name** (i.e. a name that identifies you, _not necessarily your
+legal name_) and to sign off your commits. Avoid pseudonyms or false names. Further reading about real names
+[here](https://www.mail-archive.com/kernelnewbies@kernelnewbies.org/msg22178.html).
+
+Use `git config` to set your name and email.
+
+``` sh
+# You can apply these changes locally, to a single repo
+git config --local user.name "Jane Doe"
+git config --local user.email "janedoe@janedoe.com"
+
+# Or globally
+git config --global user.name "Jane Doe"
+git config --global user.email "janedoe@janedoe.com"
+```
+
+When doing a commit, add the `-s` flag to `git commit` and that will add a `Signed-off-by: ` line to your
+commit.
+
+Aside from adding this line to the commit, it's also important to use GPG for signing your commits.
+
+GPG, or GNU Privacy Guard, is a tool that allows you to encrypt and tamperproof documents. You can use it,
+for example, to sign emails and ensure that they haven't been modified without your consent. In the git
+world, this is how you tell that a commit has been made by you and has not been tampered before reaching
+other people.
+
+Github has more [information](https://docs.github.com/en/authentication/managing-commit-signature-verification/adding-a-gpg-key-to-your-github-account)
+about how to generate and add a GPG key to your account. [This documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/telling-git-about-your-signing-key)
+teaches how to use gpgsign for commits.
+
+More information about working with GPG [here](https://git-scm.com/book/en/v2/Git-Tools-Signing-Your-Work).
+
+For even more security, you can setup [pinentry](https://www.gnupg.org/related_software/pinentry/index.html)
+to add physical layers of security to GPG, such as signing your commits with Yubikey of Touch ID.
+
 ## Rebase vs. Merge
 
 This section is a **TL;DR** of Atlassian's excellent tutorial, ["Merging vs. Rebasing"](https://www.atlassian.com/git/tutorials/merging-vs-rebasing).

--- a/README.md
+++ b/README.md
@@ -110,6 +110,10 @@ It is useful in many scenarios (e.g. multiple commits, several changes and refac
 
 ### Use the message body to explain "why", "for what", "how" and additional details
 
+Focus on the "why" instead of "what" (although "what" and "how" are still important).
+If, for example, your commit message is a restatement of the diff, it may be important to
+rethink it.
+
 ```
 # Good
 Fix method name of InventoryBackend child classes
@@ -435,3 +439,5 @@ Any kind of help would be appreciated. Example of topics that you can help me wi
 - [A Note About Git Commit Messages](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)
 - [Merging vs. Rebasing](https://www.atlassian.com/git/tutorials/merging-vs-rebasing)
 - [Pro Git Book - Rewriting History](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)
+- [Philosophy of Linux kernel patches](https://kernelnewbies.org/PatchPhilosophy)
+- [The perfect patch](https://www.ozlabs.org/~akpm/stuff/tpp.txt)


### PR DESCRIPTION
After reading the page on Patch Philosophy [1] on the Linux kernel development community, there are a few takeaways for improving commit writing and patch-making.

This repo is a valuable and extensive guide on commit messages and should be used as a way to centralize best practices seen on other open source and closed projects. 

The changes presented are: 

- Focus on why: important ideas about how to "sell" your changes to maintainers
- Writing good cover letters or PR descriptions
- Using impersonal language, as in academic writing 
- A section on signing off commits – often overlooked but rather important practice, especially in the open source community. 


[1] https://kernelnewbies.org/PatchPhilosophy